### PR TITLE
Commit for PKA-1439:

### DIFF
--- a/fprj-core/src/net/fproject/active/supportClasses/ActiveDataProviderHandler.as
+++ b/fprj-core/src/net/fproject/active/supportClasses/ActiveDataProviderHandler.as
@@ -165,6 +165,7 @@ package net.fproject.active.supportClasses
 				parent.criteria.pagination["page"] = 1;
 			
 			_fetchPending = true;
+			maxReachedIndex = -1;
 			
 			parent.setSource(null);
 			parent.setPaginationResult(null);


### PR DESCRIPTION
- Nguyên nhân gây lỗi :  không được gán lại giá trị nên khi load hết dữ liệu maxReachedIndex tăng lên và  lớn hơn số lượng bản ghi tương ứng với những điều kiện search Criteria được gửi lên sau đó vì vậy maxReachedIndex luôn lơn index dẫn tới hàm defaultQueryTrigger luôn trả về giá trị false -> sẽ ko gọi được hàm fetchNextPage();
-  mỗi khi thực hiện gọi hàm  fetchFistPage() sẽ thực hiện gán maxReachedIndex = -1 .